### PR TITLE
Hashes for attachments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         with:
             node-version: 10.x
       - name: Pack package
-      - run: npm pack
+        run: npm pack
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
             node-version: 10.x
       - name: Install package
         run: npm install
+      - name: Build package
+        run: npx gulp build
       - name: Pack package
         run: npm pack
       - name: Create Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,8 @@ jobs:
             node-version: 10.x
       - name: Install package
         run: npm install
-      - name: Build package
-        run: npx gulp build
+      - name: Build package and test
+        run: npm test
       - name: Pack package
         run: npm pack
       - name: Create Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+name: Upload Release Asset
+
+jobs:
+  build:
+    name: Upload Release Asset
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+            node-version: 10.x
+      - name: Pack package
+      - run: npm pack
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: true
+          prerelease: true
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: ./testcafe-reporter-jenkins-${{ github.ref }}.tgz
+          asset_name: testcafe-reporter-jenkins-${{ github.ref }}.tgz
+          asset_content_type: application/gzip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
         uses: actions/setup-node@v1
         with:
             node-version: 10.x
+      - name: Install package
+        run: npm install
       - name: Pack package
         run: npm pack
       - name: Create Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,9 @@ jobs:
           release_name: Release ${{ github.ref }}
           draft: true
           prerelease: true
+      - name: Get package version
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@master
       - name: Upload Release Asset
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
@@ -38,6 +41,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./testcafe-reporter-jenkins-${{ github.ref }}.tgz
-          asset_name: testcafe-reporter-jenkins-${{ github.ref }}.tgz
+          asset_path: ./testcafe-reporter-jenkins-${{ steps.package-version.outputs.current-version}}.tgz
+          asset_name: testcafe-reporter-jenkins-${{ steps.package-version.outputs.current-version}}.tgz
           asset_content_type: application/gzip

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,30 +14,30 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.9.0.tgz",
-      "integrity": "sha512-zeFQrr+284Ekvd9e7KAX954LkapWiOmQtsfHirhxqfdlX6MEC32iRE+pqUGlYIBchdevaCwvzxWGSy/YBNI85g==",
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.9.6.tgz",
+      "integrity": "sha512-5QPTrNen2bm7RBc7dsOmcA5hbrS4O2Vhmk5XOL4zWW/zD/hV0iinpefDlkm+tBBy8kDtFaaeEvmAqt+nURAV2g==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.9.1",
+        "browserslist": "^4.11.1",
         "invariant": "^2.2.4",
         "semver": "^5.5.0"
       }
     },
     "@babel/core": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
-      "integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.6.tgz",
+      "integrity": "sha512-nD3deLvbsApbHAHttzIssYqgb883yU/d9roe4RZymBCDaZryMJDbptVpEpeQuRh4BJ+SYI8le9YGxKvFEvl1Wg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.8.3",
-        "@babel/generator": "^7.9.0",
+        "@babel/generator": "^7.9.6",
         "@babel/helper-module-transforms": "^7.9.0",
-        "@babel/helpers": "^7.9.0",
-        "@babel/parser": "^7.9.0",
+        "@babel/helpers": "^7.9.6",
+        "@babel/parser": "^7.9.6",
         "@babel/template": "^7.8.6",
-        "@babel/traverse": "^7.9.0",
-        "@babel/types": "^7.9.0",
+        "@babel/traverse": "^7.9.6",
+        "@babel/types": "^7.9.6",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
@@ -46,6 +46,54 @@
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "@babel/generator": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.6.tgz",
+          "integrity": "sha512-+htwWKJbH2bL72HRluF8zumBxzuX0ZZUFl3JLNyoUjM/Ho8wnVpPXM6aUz8cfKDqQ/h7zHqKt4xzJteUosckqQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.9.6",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.6.tgz",
+          "integrity": "sha512-AoeIEJn8vt+d/6+PXDRPaksYhnlbMIiejioBZvvMQsOjW/JYK6k/0dKnvvP3EhK5GfMBWDPtrxRtegWdAcdq9Q==",
+          "dev": true
+        },
+        "@babel/traverse": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.6.tgz",
+          "integrity": "sha512-b3rAHSjbxy6VEAvlxM8OV/0X4XrG72zoxme6q1MOoe2vd0bEc+TwayhuC1+Dfgqh1QEG+pj7atQqvUprHIccsg==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/generator": "^7.9.6",
+            "@babel/helper-function-name": "^7.9.5",
+            "@babel/helper-split-export-declaration": "^7.8.3",
+            "@babel/parser": "^7.9.6",
+            "@babel/types": "^7.9.6",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/types": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.6.tgz",
+          "integrity": "sha512-qxXzvBO//jO9ZnoasKF1uJzHd2+M6Q2ZPIVfnFps8JJvXy0ZBbwbNOmE6SGIY5XOY6d1Bo5lb9d9RJ8nv3WSeA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.9.5",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/generator": {
@@ -80,13 +128,13 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.8.7.tgz",
-      "integrity": "sha512-4mWm8DCK2LugIS+p1yArqvG1Pf162upsIsjE7cNBjez+NjliQpVhj20obE520nao0o14DaTnFJv+Fw5a0JpoUw==",
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.9.6.tgz",
+      "integrity": "sha512-x2Nvu0igO0ejXzx09B/1fGBxY9NXQlBW2kZsSxCJft+KHN8t9XWzIvFxtPHnBOAXpVsdxZKZFbRUC8TsNKajMw==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.8.6",
-        "browserslist": "^4.9.1",
+        "@babel/compat-data": "^7.9.6",
+        "browserslist": "^4.11.1",
         "invariant": "^2.2.4",
         "levenary": "^1.1.1",
         "semver": "^5.5.0"
@@ -224,15 +272,63 @@
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.8.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz",
-      "integrity": "sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==",
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.9.6.tgz",
+      "integrity": "sha512-qX+chbxkbArLyCImk3bWV+jB5gTNU/rsze+JlcF6Nf8tVTigPJSI1o1oBow/9Resa1yehUO9lIipsmu9oG4RzA==",
       "dev": true,
       "requires": {
         "@babel/helper-member-expression-to-functions": "^7.8.3",
         "@babel/helper-optimise-call-expression": "^7.8.3",
-        "@babel/traverse": "^7.8.6",
-        "@babel/types": "^7.8.6"
+        "@babel/traverse": "^7.9.6",
+        "@babel/types": "^7.9.6"
+      },
+      "dependencies": {
+        "@babel/generator": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.6.tgz",
+          "integrity": "sha512-+htwWKJbH2bL72HRluF8zumBxzuX0ZZUFl3JLNyoUjM/Ho8wnVpPXM6aUz8cfKDqQ/h7zHqKt4xzJteUosckqQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.9.6",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.6.tgz",
+          "integrity": "sha512-AoeIEJn8vt+d/6+PXDRPaksYhnlbMIiejioBZvvMQsOjW/JYK6k/0dKnvvP3EhK5GfMBWDPtrxRtegWdAcdq9Q==",
+          "dev": true
+        },
+        "@babel/traverse": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.6.tgz",
+          "integrity": "sha512-b3rAHSjbxy6VEAvlxM8OV/0X4XrG72zoxme6q1MOoe2vd0bEc+TwayhuC1+Dfgqh1QEG+pj7atQqvUprHIccsg==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/generator": "^7.9.6",
+            "@babel/helper-function-name": "^7.9.5",
+            "@babel/helper-split-export-declaration": "^7.8.3",
+            "@babel/parser": "^7.9.6",
+            "@babel/types": "^7.9.6",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/types": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.6.tgz",
+          "integrity": "sha512-qxXzvBO//jO9ZnoasKF1uJzHd2+M6Q2ZPIVfnFps8JJvXy0ZBbwbNOmE6SGIY5XOY6d1Bo5lb9d9RJ8nv3WSeA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.9.5",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-simple-access": {
@@ -273,14 +369,62 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.9.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.9.2.tgz",
-      "integrity": "sha512-JwLvzlXVPjO8eU9c/wF9/zOIN7X6h8DYf7mG4CiFRZRvZNKEF5dQ3H3V+ASkHoIB3mWhatgl5ONhyqHRI6MppA==",
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.9.6.tgz",
+      "integrity": "sha512-tI4bUbldloLcHWoRUMAj4g1bF313M/o6fBKhIsb3QnGVPwRm9JsNf/gqMkQ7zjqReABiffPV6RWj7hEglID5Iw==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.8.3",
-        "@babel/traverse": "^7.9.0",
-        "@babel/types": "^7.9.0"
+        "@babel/traverse": "^7.9.6",
+        "@babel/types": "^7.9.6"
+      },
+      "dependencies": {
+        "@babel/generator": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.6.tgz",
+          "integrity": "sha512-+htwWKJbH2bL72HRluF8zumBxzuX0ZZUFl3JLNyoUjM/Ho8wnVpPXM6aUz8cfKDqQ/h7zHqKt4xzJteUosckqQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.9.6",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.6.tgz",
+          "integrity": "sha512-AoeIEJn8vt+d/6+PXDRPaksYhnlbMIiejioBZvvMQsOjW/JYK6k/0dKnvvP3EhK5GfMBWDPtrxRtegWdAcdq9Q==",
+          "dev": true
+        },
+        "@babel/traverse": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.6.tgz",
+          "integrity": "sha512-b3rAHSjbxy6VEAvlxM8OV/0X4XrG72zoxme6q1MOoe2vd0bEc+TwayhuC1+Dfgqh1QEG+pj7atQqvUprHIccsg==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/generator": "^7.9.6",
+            "@babel/helper-function-name": "^7.9.5",
+            "@babel/helper-split-export-declaration": "^7.8.3",
+            "@babel/parser": "^7.9.6",
+            "@babel/types": "^7.9.6",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/types": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.6.tgz",
+          "integrity": "sha512-qxXzvBO//jO9ZnoasKF1uJzHd2+M6Q2ZPIVfnFps8JJvXy0ZBbwbNOmE6SGIY5XOY6d1Bo5lb9d9RJ8nv3WSeA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.9.5",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/highlight": {
@@ -352,9 +496,9 @@
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.9.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.9.5.tgz",
-      "integrity": "sha512-VP2oXvAf7KCYTthbUHwBlewbl1Iq059f6seJGsxMizaCdgHIeczOr7FBqELhSqfkIl04Fi8okzWzl63UKbQmmg==",
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.9.6.tgz",
+      "integrity": "sha512-Ga6/fhGqA9Hj+y6whNpPv8psyaK5xzrQwSPsGPloVkvmH+PqW1ixdnfJ9uIO06OjQNYol3PMnfmJ8vfZtkzF+A==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3",
@@ -613,38 +757,38 @@
       }
     },
     "@babel/plugin-transform-modules-amd": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.9.0.tgz",
-      "integrity": "sha512-vZgDDF003B14O8zJy0XXLnPH4sg+9X5hFBBGN1V+B2rgrB+J2xIypSN6Rk9imB2hSTHQi5OHLrFWsZab1GMk+Q==",
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.9.6.tgz",
+      "integrity": "sha512-zoT0kgC3EixAyIAU+9vfaUVKTv9IxBDSabgHoUCBP6FqEJ+iNiN7ip7NBKcYqbfUDfuC2mFCbM7vbu4qJgOnDw==",
       "dev": true,
       "requires": {
         "@babel/helper-module-transforms": "^7.9.0",
         "@babel/helper-plugin-utils": "^7.8.3",
-        "babel-plugin-dynamic-import-node": "^2.3.0"
+        "babel-plugin-dynamic-import-node": "^2.3.3"
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.9.0.tgz",
-      "integrity": "sha512-qzlCrLnKqio4SlgJ6FMMLBe4bySNis8DFn1VkGmOcxG9gqEyPIOzeQrA//u0HAKrWpJlpZbZMPB1n/OPa4+n8g==",
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.9.6.tgz",
+      "integrity": "sha512-7H25fSlLcn+iYimmsNe3uK1at79IE6SKW9q0/QeEHTMC9MdOZ+4bA+T1VFB5fgOqBWoqlifXRzYD0JPdmIrgSQ==",
       "dev": true,
       "requires": {
         "@babel/helper-module-transforms": "^7.9.0",
         "@babel/helper-plugin-utils": "^7.8.3",
         "@babel/helper-simple-access": "^7.8.3",
-        "babel-plugin-dynamic-import-node": "^2.3.0"
+        "babel-plugin-dynamic-import-node": "^2.3.3"
       }
     },
     "@babel/plugin-transform-modules-systemjs": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.9.0.tgz",
-      "integrity": "sha512-FsiAv/nao/ud2ZWy4wFacoLOm5uxl0ExSQ7ErvP7jpoihLR6Cq90ilOFyX9UXct3rbtKsAiZ9kFt5XGfPe/5SQ==",
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.9.6.tgz",
+      "integrity": "sha512-NW5XQuW3N2tTHim8e1b7qGy7s0kZ2OH3m5octc49K1SdAKGxYxeIx7hiIz05kS1R2R+hOWcsr1eYwcGhrdHsrg==",
       "dev": true,
       "requires": {
         "@babel/helper-hoist-variables": "^7.8.3",
         "@babel/helper-module-transforms": "^7.9.0",
         "@babel/helper-plugin-utils": "^7.8.3",
-        "babel-plugin-dynamic-import-node": "^2.3.0"
+        "babel-plugin-dynamic-import-node": "^2.3.3"
       }
     },
     "@babel/plugin-transform-modules-umd": {
@@ -780,13 +924,13 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.9.5",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.9.5.tgz",
-      "integrity": "sha512-eWGYeADTlPJH+wq1F0wNfPbVS1w1wtmMJiYk55Td5Yu28AsdR9AsC97sZ0Qq8fHqQuslVSIYSGJMcblr345GfQ==",
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.9.6.tgz",
+      "integrity": "sha512-0gQJ9RTzO0heXOhzftog+a/WyOuqMrAIugVYxMYf83gh1CQaQDjMtsOpqOwXyDL/5JcWsrCm8l4ju8QC97O7EQ==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.9.0",
-        "@babel/helper-compilation-targets": "^7.8.7",
+        "@babel/compat-data": "^7.9.6",
+        "@babel/helper-compilation-targets": "^7.9.6",
         "@babel/helper-module-imports": "^7.8.3",
         "@babel/helper-plugin-utils": "^7.8.3",
         "@babel/plugin-proposal-async-generator-functions": "^7.8.3",
@@ -794,7 +938,7 @@
         "@babel/plugin-proposal-json-strings": "^7.8.3",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
         "@babel/plugin-proposal-numeric-separator": "^7.8.3",
-        "@babel/plugin-proposal-object-rest-spread": "^7.9.5",
+        "@babel/plugin-proposal-object-rest-spread": "^7.9.6",
         "@babel/plugin-proposal-optional-catch-binding": "^7.8.3",
         "@babel/plugin-proposal-optional-chaining": "^7.9.0",
         "@babel/plugin-proposal-unicode-property-regex": "^7.8.3",
@@ -821,9 +965,9 @@
         "@babel/plugin-transform-function-name": "^7.8.3",
         "@babel/plugin-transform-literals": "^7.8.3",
         "@babel/plugin-transform-member-expression-literals": "^7.8.3",
-        "@babel/plugin-transform-modules-amd": "^7.9.0",
-        "@babel/plugin-transform-modules-commonjs": "^7.9.0",
-        "@babel/plugin-transform-modules-systemjs": "^7.9.0",
+        "@babel/plugin-transform-modules-amd": "^7.9.6",
+        "@babel/plugin-transform-modules-commonjs": "^7.9.6",
+        "@babel/plugin-transform-modules-systemjs": "^7.9.6",
         "@babel/plugin-transform-modules-umd": "^7.9.0",
         "@babel/plugin-transform-named-capturing-groups-regex": "^7.8.3",
         "@babel/plugin-transform-new-target": "^7.8.3",
@@ -839,12 +983,25 @@
         "@babel/plugin-transform-typeof-symbol": "^7.8.4",
         "@babel/plugin-transform-unicode-regex": "^7.8.3",
         "@babel/preset-modules": "^0.1.3",
-        "@babel/types": "^7.9.5",
-        "browserslist": "^4.9.1",
+        "@babel/types": "^7.9.6",
+        "browserslist": "^4.11.1",
         "core-js-compat": "^3.6.2",
         "invariant": "^2.2.2",
         "levenary": "^1.1.1",
         "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.6.tgz",
+          "integrity": "sha512-qxXzvBO//jO9ZnoasKF1uJzHd2+M6Q2ZPIVfnFps8JJvXy0ZBbwbNOmE6SGIY5XOY6d1Bo5lb9d9RJ8nv3WSeA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.9.5",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/preset-modules": {
@@ -861,9 +1018,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.9.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
-      "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.6.tgz",
+      "integrity": "sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
@@ -1684,9 +1841,9 @@
       }
     },
     "babel-plugin-dynamic-import-node": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.2.tgz",
-      "integrity": "sha512-yvczAMjbc73xira9yTyF1XnEmkX8QwlUhmxuhimeMUeAaA6s7busTPRVDzhVG7eeBdNcRiZ/mAwFrJ9It4vQcg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+      "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
       "dev": true,
       "requires": {
         "object.assign": "^4.1.0"
@@ -6455,9 +6612,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.53",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.53.tgz",
-      "integrity": "sha512-wp8zyQVwef2hpZ/dJH7SfSrIPD6YoJz6BDQDpGEkcA0s3LpAQoxBIYmfIq6QAhC1DhwsyCgTaTTcONwX8qzCuQ==",
+      "version": "1.1.55",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.55.tgz",
+      "integrity": "sha512-H3R3YR/8TjT5WPin/wOoHOUPHgvj8leuU/Keta/rwelEQN9pA/S2Dx8/se4pZ2LBxSd0nAGzsNzhqwa77v7F1w==",
       "dev": true
     },
     "node-version": {
@@ -9108,9 +9265,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
+      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw=="
     },
     "v8-compile-cache": {
       "version": "2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9107,6 +9107,11 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
+    "uuid": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
+    },
     "v8-compile-cache": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-reporter-jenkins",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-reporter-jenkins",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Jenkins JUnit compatible TestCafe reporter plugin.",
   "repository": "https://github.com/wentwrong/testcafe-reporter-jenkins",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-reporter-jenkins",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "description": "Jenkins JUnit compatible TestCafe reporter plugin.",
   "repository": "https://github.com/wentwrong/testcafe-reporter-jenkins",
   "author": {

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@babel/core": "^7.9.0",
-    "@babel/preset-env": "^7.9.5",
+    "@babel/core": "^7.9.6",
+    "@babel/preset-env": "^7.9.6",
     "babel-eslint": "^10.1.0",
     "babel-plugin-add-module-exports": "^1.0.2",
     "callsite-record": "^4.1.3",
@@ -43,6 +43,6 @@
     "testcafe": "^1.8.4"
   },
   "dependencies": {
-    "uuid": "^7.0.3"
+    "uuid": "^8.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,5 +42,7 @@
     "read-file-relative": "^1.2.0",
     "testcafe": "^1.8.4"
   },
-  "dependencies": {}
+  "dependencies": {
+    "uuid": "^7.0.3"
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from 'uuid';
+
 export default function () {
     return {
         noColors:           true,
@@ -39,12 +41,12 @@ export default function () {
 
             if (hasScreenshots) {
                 for (const screenshot of testRunInfo.screenshots)
-                    this.report += this.indentString(`[[ATTACHMENT|${screenshot.screenshotPath}]]\n`, 6);
+                    this.report += this.indentString(`[[ATTACHMENT|${screenshot.screenshotPath}|${uuidv4()}]]\n`, 6);
             }
 
             if (hasVideos) {
                 for (const video of testRunInfo.videos)
-                    this.report += this.indentString(`[[ATTACHMENT|${video.videoPath}]]\n`, 6);
+                    this.report += this.indentString(`[[ATTACHMENT|${video.videoPath}|${uuidv4()}]]\n`, 6);
             }
 
             this.report += this.indentString(']]>\n', 4);

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ export default function () {
 
             if (hasScreenshots) {
                 for (const screenshot of testRunInfo.screenshots)
-                    this.report += this.indentString(`[[ATTACHMENT|${screenshot.screenshotPath}|${uuidv4()}]]\n`, 6);
+                    this.report += this.indentString(`[[screenshot|${screenshot.screenshotPath}|${uuidv4()}]]\n`, 6);
             }
 
             if (hasVideos) {
@@ -52,7 +52,7 @@ export default function () {
 
                     const videoHash = video.singleFile ? this.singleVideoHash : uuidv4();
 
-                    this.report += this.indentString(`[[ATTACHMENT|${video.videoPath}|${videoHash}]]\n`, 6);
+                    this.report += this.indentString(`[[video|${video.videoPath}|${videoHash}]]\n`, 6);
                 }
             }
 

--- a/src/index.js
+++ b/src/index.js
@@ -67,8 +67,8 @@ export default function () {
 
             name = this.escapeHtml(name);
 
-            var openTag = `<testcase classname="${this.currentFixtureName}" ` +
-                          `name="${name}" time="${testRunInfo.durationMs / 1000}">\n`;
+            const openTag = `<testcase classname="${this.currentFixtureName}" ` +
+                            `name="${name}" time="${testRunInfo.durationMs / 1000}">\n`;
 
             this.report += this.indentString(openTag, 2);
 
@@ -111,13 +111,13 @@ export default function () {
         },
 
         async reportTaskDone (endTime, passed, warnings, result) {
-            var name     = `TestCafe Tests: ${this.escapeHtml(this.uaList)}`;
-            var time     = (endTime - this.startTime) / 1000;
+            const name     = `TestCafe Tests: ${this.escapeHtml(this.uaList)}`;
+            const time     = (endTime - this.startTime) / 1000;
 
             this.write('<?xml version="1.0" encoding="UTF-8" ?>')
                 .newline()
                 .write(`<testsuite name="${name}" tests="${this.testCount}" failures="${result.failedCount}" ` +
-                       `skipped="${result.skippedCount}" errors="${result.failedCount}" time="${time}" ` +
+                       `skipped="${result.skippedCount}" time="${time}" ` +
                        `timestamp="${endTime.toUTCString()}" id="${uuidv4()}">`)
                 .newline()
                 .write(this.report);

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ export default function () {
         uaList:             null,
         currentFixtureName: null,
         testCount:          0,
+        singleVideoHash:    null,
 
         async reportTaskStart (startTime, userAgents, testCount) {
             this.startTime = startTime;
@@ -45,8 +46,14 @@ export default function () {
             }
 
             if (hasVideos) {
-                for (const video of testRunInfo.videos)
-                    this.report += this.indentString(`[[ATTACHMENT|${video.videoPath}|${uuidv4()}]]\n`, 6);
+                for (const video of testRunInfo.videos) {
+                    if (video.singleFile)
+                        this.singleVideoHash = this.singleVideoHash || uuidv4();
+
+                    const videoHash = video.singleFile ? this.singleVideoHash : uuidv4();
+
+                    this.report += this.indentString(`[[ATTACHMENT|${video.videoPath}|${videoHash}]]\n`, 6);
+                }
             }
 
             this.report += this.indentString(']]>\n', 4);

--- a/src/index.js
+++ b/src/index.js
@@ -118,7 +118,7 @@ export default function () {
                 .newline()
                 .write(`<testsuite name="${name}" tests="${this.testCount}" failures="${result.failedCount}" ` +
                        `skipped="${result.skippedCount}" errors="${result.failedCount}" time="${time}" ` +
-                       `timestamp="${endTime.toUTCString()}" >`)
+                       `timestamp="${endTime.toUTCString()}" id="${uuidv4()}">`)
                 .newline()
                 .write(this.report);
 

--- a/test/data/report-with-colors.xml
+++ b/test/data/report-with-colors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<testsuite name="TestCafe Tests: Chrome 41.0.2227 / Mac OS X 10.10.1, Firefox 47 / Mac OS X 10.10.1" tests="7" failures="2" skipped="0" errors="2" time="925" timestamp="Thu, 01 Jan 1970 00:15:25 GMT" id="UUID">
+<testsuite name="TestCafe Tests: Chrome 41.0.2227 / Mac OS X 10.10.1, Firefox 47 / Mac OS X 10.10.1" tests="7" failures="2" skipped="0" time="925" timestamp="Thu, 01 Jan 1970 00:15:25 GMT" id="UUID">
   <testcase classname="First fixture" name="First test in first fixture" time="74">
     <system-out>
     <![CDATA[

--- a/test/data/report-with-colors.xml
+++ b/test/data/report-with-colors.xml
@@ -3,7 +3,7 @@
   <testcase classname="First fixture" name="First test in first fixture" time="74">
     <system-out>
     <![CDATA[
-      [[ATTACHMENT|/screenshots/1445437598847]]
+      [[ATTACHMENT|/screenshots/1445437598847|UUID]]
     ]]>
     </system-out>
   </testcase>
@@ -63,9 +63,9 @@
     </failure>
     <system-out>
     <![CDATA[
-      [[ATTACHMENT|/screenshots/1445437598847]]
-      [[ATTACHMENT|/screenshots/1445437598847]]
-      [[ATTACHMENT|/videos/1445437598847]]
+      [[ATTACHMENT|/screenshots/1445437598847|UUID]]
+      [[ATTACHMENT|/screenshots/1445437598847|UUID]]
+      [[ATTACHMENT|/videos/1445437598847|UUID]]
     ]]>
     </system-out>
   </testcase>
@@ -107,7 +107,7 @@
     </failure>
     <system-out>
     <![CDATA[
-      [[ATTACHMENT|/screenshots/1445437598847]]
+      [[ATTACHMENT|/screenshots/1445437598847|UUID]]
     ]]>
     </system-out>
   </testcase>

--- a/test/data/report-with-colors.xml
+++ b/test/data/report-with-colors.xml
@@ -3,7 +3,7 @@
   <testcase classname="First fixture" name="First test in first fixture" time="74">
     <system-out>
     <![CDATA[
-      [[ATTACHMENT|/screenshots/1445437598847|UUID]]
+      [[screenshot|/screenshots/1445437598847|UUID]]
     ]]>
     </system-out>
   </testcase>
@@ -63,9 +63,9 @@
     </failure>
     <system-out>
     <![CDATA[
-      [[ATTACHMENT|/screenshots/1445437598847|UUID]]
-      [[ATTACHMENT|/screenshots/1445437598847|UUID]]
-      [[ATTACHMENT|/videos/1445437598847|UUID]]
+      [[screenshot|/screenshots/1445437598847|UUID]]
+      [[screenshot|/screenshots/1445437598847|UUID]]
+      [[video|/videos/1445437598847|UUID]]
     ]]>
     </system-out>
   </testcase>
@@ -107,7 +107,7 @@
     </failure>
     <system-out>
     <![CDATA[
-      [[ATTACHMENT|/screenshots/1445437598847|UUID]]
+      [[screenshot|/screenshots/1445437598847|UUID]]
     ]]>
     </system-out>
   </testcase>

--- a/test/data/report-with-colors.xml
+++ b/test/data/report-with-colors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<testsuite name="TestCafe Tests: Chrome 41.0.2227 / Mac OS X 10.10.1, Firefox 47 / Mac OS X 10.10.1" tests="7" failures="2" skipped="0" errors="2" time="925" timestamp="Thu, 01 Jan 1970 00:15:25 GMT" >
+<testsuite name="TestCafe Tests: Chrome 41.0.2227 / Mac OS X 10.10.1, Firefox 47 / Mac OS X 10.10.1" tests="7" failures="2" skipped="0" errors="2" time="925" timestamp="Thu, 01 Jan 1970 00:15:25 GMT" id="UUID">
   <testcase classname="First fixture" name="First test in first fixture" time="74">
     <system-out>
     <![CDATA[

--- a/test/data/report-without-colors.xml
+++ b/test/data/report-without-colors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<testsuite name="TestCafe Tests: Chrome 41.0.2227 / Mac OS X 10.10.1, Firefox 47 / Mac OS X 10.10.1" tests="7" failures="2" skipped="0" errors="2" time="925" timestamp="Thu, 01 Jan 1970 00:15:25 GMT" id="UUID">
+<testsuite name="TestCafe Tests: Chrome 41.0.2227 / Mac OS X 10.10.1, Firefox 47 / Mac OS X 10.10.1" tests="7" failures="2" skipped="0" time="925" timestamp="Thu, 01 Jan 1970 00:15:25 GMT" id="UUID">
   <testcase classname="First fixture" name="First test in first fixture" time="74">
     <system-out>
     <![CDATA[

--- a/test/data/report-without-colors.xml
+++ b/test/data/report-without-colors.xml
@@ -3,7 +3,7 @@
   <testcase classname="First fixture" name="First test in first fixture" time="74">
     <system-out>
     <![CDATA[
-      [[ATTACHMENT|/screenshots/1445437598847]]
+      [[ATTACHMENT|/screenshots/1445437598847|UUID]]
     ]]>
     </system-out>
   </testcase>
@@ -63,9 +63,9 @@
     </failure>
     <system-out>
     <![CDATA[
-      [[ATTACHMENT|/screenshots/1445437598847]]
-      [[ATTACHMENT|/screenshots/1445437598847]]
-      [[ATTACHMENT|/videos/1445437598847]]
+      [[ATTACHMENT|/screenshots/1445437598847|UUID]]
+      [[ATTACHMENT|/screenshots/1445437598847|UUID]]
+      [[ATTACHMENT|/videos/1445437598847|UUID]]
     ]]>
     </system-out>
   </testcase>
@@ -107,7 +107,7 @@
     </failure>
     <system-out>
     <![CDATA[
-      [[ATTACHMENT|/screenshots/1445437598847]]
+      [[ATTACHMENT|/screenshots/1445437598847|UUID]]
     ]]>
     </system-out>
   </testcase>

--- a/test/data/report-without-colors.xml
+++ b/test/data/report-without-colors.xml
@@ -3,7 +3,7 @@
   <testcase classname="First fixture" name="First test in first fixture" time="74">
     <system-out>
     <![CDATA[
-      [[ATTACHMENT|/screenshots/1445437598847|UUID]]
+      [[screenshot|/screenshots/1445437598847|UUID]]
     ]]>
     </system-out>
   </testcase>
@@ -63,9 +63,9 @@
     </failure>
     <system-out>
     <![CDATA[
-      [[ATTACHMENT|/screenshots/1445437598847|UUID]]
-      [[ATTACHMENT|/screenshots/1445437598847|UUID]]
-      [[ATTACHMENT|/videos/1445437598847|UUID]]
+      [[screenshot|/screenshots/1445437598847|UUID]]
+      [[screenshot|/screenshots/1445437598847|UUID]]
+      [[video|/videos/1445437598847|UUID]]
     ]]>
     </system-out>
   </testcase>
@@ -107,7 +107,7 @@
     </failure>
     <system-out>
     <![CDATA[
-      [[ATTACHMENT|/screenshots/1445437598847|UUID]]
+      [[screenshot|/screenshots/1445437598847|UUID]]
     ]]>
     </system-out>
   </testcase>

--- a/test/data/report-without-colors.xml
+++ b/test/data/report-without-colors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<testsuite name="TestCafe Tests: Chrome 41.0.2227 / Mac OS X 10.10.1, Firefox 47 / Mac OS X 10.10.1" tests="7" failures="2" skipped="0" errors="2" time="925" timestamp="Thu, 01 Jan 1970 00:15:25 GMT" >
+<testsuite name="TestCafe Tests: Chrome 41.0.2227 / Mac OS X 10.10.1, Firefox 47 / Mac OS X 10.10.1" tests="7" failures="2" skipped="0" errors="2" time="925" timestamp="Thu, 01 Jan 1970 00:15:25 GMT" id="UUID">
   <testcase classname="First fixture" name="First test in first fixture" time="74">
     <system-out>
     <![CDATA[

--- a/test/utils/create-report.js
+++ b/test/utils/create-report.js
@@ -39,7 +39,7 @@ module.exports = async function createReport (withColors) {
     outStream.data = outStream.data.replace(/\(.+:\d+:\d+.*\)/g, '(some-file:1:1)');
 
     // NOTE: mock attachments UUID hashes
-    outStream.data = outStream.data.replace(/\[\[ATTACHMENT\|(.*)\|(.*)\]\]/g, '[[ATTACHMENT|$1|UUID]]');
+    outStream.data = outStream.data.replace(/\[\[(.*)\|(.*)\|(.*)\]\]/g, '[[$1|$2|UUID]]');
 
     // NOTE: mock suite UUID hash
     outStream.data = outStream.data.replace(/id="(.*)"/g, 'id="UUID"');

--- a/test/utils/create-report.js
+++ b/test/utils/create-report.js
@@ -41,5 +41,8 @@ module.exports = async function createReport (withColors) {
     // NOTE: mock attachments UUID hashes
     outStream.data = outStream.data.replace(/\[\[ATTACHMENT\|(.*)\|(.*)\]\]/g, '[[ATTACHMENT|$1|UUID]]');
 
+    // NOTE: mock suite UUID hash
+    outStream.data = outStream.data.replace(/id="(.*)"/g, 'id="UUID"');
+
     return outStream.data;
 };

--- a/test/utils/create-report.js
+++ b/test/utils/create-report.js
@@ -36,5 +36,10 @@ module.exports = async function createReport (withColors) {
         await plugin[call.method].apply(plugin, call.args);
 
     // NOTE: mock stack entries
-    return outStream.data.replace(/\(.+:\d+:\d+.*\)/g, '(some-file:1:1)');
+    outStream.data = outStream.data.replace(/\(.+:\d+:\d+.*\)/g, '(some-file:1:1)');
+
+    // NOTE: mock attachments UUID hashes
+    outStream.data = outStream.data.replace(/\[\[ATTACHMENT\|(.*)\|(.*)\]\]/g, '[[ATTACHMENT|$1|UUID]]');
+
+    return outStream.data;
 };

--- a/test/utils/create-report.js
+++ b/test/utils/create-report.js
@@ -3,7 +3,7 @@ var pluginFactory       = require('../../lib');
 var reporterTestCalls   = require('./reporter-test-calls');
 
 module.exports = async function createReport (withColors) {
-    var outStream = {
+    const outStream = {
         data: '',
 
         write: function (text) {
@@ -11,7 +11,7 @@ module.exports = async function createReport (withColors) {
         }
     };
 
-    var plugin = buildReporterPlugin(pluginFactory, outStream);
+    const plugin = buildReporterPlugin(pluginFactory, outStream);
 
     plugin.chalk.enabled = !plugin.noColors && withColors;
 


### PR DESCRIPTION
## Purpose
As [described in plugin for Jenkins](https://github.com/wentwrong/testcafe-jenkins-plugin/pull/1#issuecomment-621079138), hashes are needed for providing uniqueness of attachments when they are moved from agent to master.